### PR TITLE
Adjust assembly process to allow build-essential to complete.

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -46,11 +46,15 @@ def assemble(target):
 
             for it in defs.lookup(this, 'contents'):
                 component = defs.get(it)
+                if component.get('build-mode') == 'bootstrap':
+                    continue
                 assemble(component)
                 sandbox.install_artifact(this, component)
 
-            if this.get('build-mode') == 'staging':
+            if this.get('build-mode') != 'bootstrap':
                 sandbox.ldconfig(this)
+            else:
+                app.log(this, "No ldconfig because bootstrap mode is engaged")
 
             build(this)
 


### PR DESCRIPTION
The assembly process was putting bootstrap chunks into the sandbox
when said chunks were not build dependencies.  In addition it was
failing to run ldconfig in non-bootstrap cases.

This commit fixes that.