### PR TITLE
Deployment improvements and fixes

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -33,9 +33,6 @@ def deploy(target):
     defs = Definitions()
     deployment = target if type(target) is dict else defs.get(target)
 
-    if deployment.get('systems') == None:
-        return
-
     with app.timer(deployment, 'Starting deployment'):
         for system in deployment.get('systems', []):
             deploy(system)

--- a/assembly.py
+++ b/assembly.py
@@ -46,7 +46,7 @@ def deploy(target):
 
         with sandbox.setup(system):
             for name, deployment in deployment.get('deploy', {}).iteritems():
-                method = deployment['type']
+                method = os.path.basename(deployment['type'])
                 sandbox.run_extension(system, deployment, 'check', method)
                 app.log(system, "Extracting system artifact")
                 with open(cache.get_cache(system), "r") as artifact:
@@ -54,7 +54,8 @@ def deploy(target):
                          stdin=artifact)
 
                 for ext in system.get('configuration-extensions', []):
-                    sandbox.run_extension(system, deployment, 'configure', ext)
+                    sandbox.run_extension(system, deployment, 'configure',
+                                          os.path.basename(ext))
 
                 os.chmod(system['sandbox'], 0o755)
                 sandbox.run_extension(system, deployment, 'write', method)

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ including, for example
 - GENIVI baseline systems
 - OpenStack appliances
 
-It can also deploy some systems in some ways, by piggybacking morphlib. More work is needed to make that functionality tidy and reliable, without morphlib.
+It can also deploy some systems in some ways.
 
 YBD is under development. Things will change :)
 
@@ -45,7 +45,6 @@ Currently YBD generates a lot of log output, which hopefully helps to explain wh
   - easier to try things, easier to change things, easier to debug things
   - less to break, less to maintain, less to audit
 - ybd has minimal dependencies - just git and a 'normal' Linux toolchain
-  (but for deploy it is currently using morph's plugins, which is not ideal)
 - ybd has faster, simpler calculation of cache-keys, and faster resolution of
   build-order
 - ybd can drop the words morphology, stratum, chunk from the Baserock vocabulary

--- a/sandbox.py
+++ b/sandbox.py
@@ -210,20 +210,23 @@ def run_extension(this, deployment, step, method):
         if key.isupper():
             envlist.append("%s=%s" % (key, value))
 
-    command = ["env"] + envlist + [cmd_bin]
-
-    if step == 'check':
-        command += [deployment['location']]
-
-    if step == 'configure':
-        command += [this['sandbox']]
+    command = ["env"] + envlist + [cmd_tmp.name] + [this['sandbox']]
 
     if step == 'write':
-        command += [this['sandbox']] + [deployment['location']]
+        command += [deployment['location']]
 
-    with app.chdir(app.settings['defdir']):
-        if call(command):
-            app.exit(this, 'ERROR: %s extension failed:' % step, cmd_bin)
+    with app.chdir(this['sandbox']):
+        try:
+            with open(cmd_bin, "r") as infh:
+                shutil.copyfileobj(infh, cmd_tmp)
+            cmd_tmp.close()
+            os.chmod(cmd_tmp.name, 0o700)
+
+            if call(command):
+                app.log(this, 'ERROR: %s extension failed:' % step, cmd_bin)
+                raise SystemExit
+        finally:
+            os.remove(cmd_tmp.name)
     return
 
 

--- a/sandbox.py
+++ b/sandbox.py
@@ -210,10 +210,13 @@ def run_extension(this, deployment, step, method):
         if key.isupper():
             envlist.append("%s=%s" % (key, value))
 
-    command = ["env"] + envlist + [cmd_tmp.name] + [this['sandbox']]
+    command = ["env"] + envlist + [cmd_tmp.name]
 
-    if step == 'write':
-        command += [deployment['location']]
+    if step in ('write', 'configure'):
+        command.append(this['sandbox'])
+
+    if step in ('write', 'check'):
+        command.append(deployment['location'])
 
     with app.chdir(app.settings['defdir']):
         try:

--- a/sandbox.py
+++ b/sandbox.py
@@ -201,7 +201,7 @@ def run_extension(this, deployment, step, method):
     cmd_tmp = tempfile.NamedTemporaryFile(delete=False)
     cmd_bin = extensions[step][method]
 
-    if deployment['type'] == 'ssh-rsync':
+    if method == 'ssh-rsync':
         envlist = ['UPGRADE=yes']
     else:
         envlist = ['UPGRADE=no']
@@ -215,7 +215,7 @@ def run_extension(this, deployment, step, method):
     if step == 'write':
         command += [deployment['location']]
 
-    with app.chdir(this['sandbox']):
+    with app.chdir(app.settings['defdir']):
         try:
             with open(cmd_bin, "r") as infh:
                 shutil.copyfileobj(infh, cmd_tmp)

--- a/utils.py
+++ b/utils.py
@@ -321,19 +321,8 @@ def _find_extensions(paths):
 
 
 def find_extensions():
-    '''Scan morphlib, ybd source, and definitions for extensions.'''
+    '''Scan definitions for extensions.'''
 
-    paths = []
-
-    try:
-        import morphlib
-        morphlib_dir = os.path.dirname(morphlib.__file__)
-        paths.append(os.path.join(morphlib_dir, 'exts'))
-    except:
-        app.log("EXTENSIONS", "WARNING: unable to locate morphlib")
-
-    ybd_dir = os.path.dirname(__file__)
-    paths.append(os.path.join(ybd_dir, 'exts'))
-    paths.append(app.settings['defdir'])
+    paths = [os.path.join(app.settings['defdir'], 'extensions')]
 
     return _find_extensions(paths)

--- a/utils.py
+++ b/utils.py
@@ -308,9 +308,11 @@ def _find_extensions(paths):
 
     def scan_path(path):
         for kind in extension_kinds:
-            for entry in glob.glob(os.path.join(path, '*.' + kind)):
-                base = os.path.splitext(os.path.basename(entry))[0]
-                ret[kind][base] = entry
+            for dirpath, dirnames, filenames in os.walk(path):
+                for filename in filenames:
+                    if filename.endswith(kind):
+                        filepath = os.path.join(dirpath, filename)
+                        ret[kind][os.path.splitext(filename)[0]] = filepath
 
     for p in paths:
         scan_path(p)


### PR DESCRIPTION
This is a set of fixes and improvements to deployment, which allows systems to be deployed when extensions are in subdirectories as is the case in current master of definitions. It also removes the dependency on morphlib now that all the extensions are in definitions.

NOTE: Some of the deployment extensions still depend on morphlib, so only a subset of the deployment extensions will work on a system without morph.