### PR TITLE
ybd: Add environment variable to set timezone to UTC

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -293,6 +293,7 @@ def clean_env(this):
     env['USER'] = env['USERNAME'] = env['LOGNAME'] = 'tomjon'
     env['LC_ALL'] = 'C'
     env['HOME'] = '/tmp'
+    env['TZ'] = 'UTC'
 
     arch = app.settings['arch']
     cpu = 'i686' if arch == 'x86_32' else arch


### PR DESCRIPTION
This should work towards solving #31 and improving reproducibility; as far as I am aware there is no current time standard in YBD, meaning that build reproducibility could be affected by builds being ran in different timezones.