### PR TITLE
Fix crash on 'xx is not a git repo' error

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,7 @@ def setup(target, arch):
         settings['pid'] = os.getpid()
         with open(os.devnull, "w") as fnull:
             if call(['git', 'describe'], stdout=fnull, stderr=fnull):
-                exit(target, 'ERROR: %s is not a git repo' % os.getcwd())
+                exit(target, 'ERROR: not a git repo', os.getcwd())
 
         settings['ybd-version'] = get_version(os.path.dirname(__file__))
         settings['defdir'] = os.getcwd()


### PR DESCRIPTION
Seems the prototype of the exit() function changed.

    Traceback (most recent call last):
      File "../ybd/ybd.py", line 40, in <module>
        with app.setup(target, arch):
      File "/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
        return self.gen.next()
      File "/home/shared/baserock-chroot-src/ybd/app.py", line 78, in setup
        exit(target, 'ERROR: %s is not a git repo' % os.getcwd())
    TypeError: exit() takes exactly 3 arguments (2 given)