### PR TITLE
Show name of Git repo when resolving a tree fails

### DIFF
--- a/repos.py
+++ b/repos.py
@@ -100,7 +100,7 @@ def get_tree(this):
             # either we don't have a git dir, or ref is not unique
             # or ref does not exist
 
-            app.exit(this, 'ERROR: could not find tree for ref', ref)
+            app.exit(this, 'ERROR: could not find tree for ref', (ref, gitdir))
 
 
 def mirror(name, repo):


### PR DESCRIPTION
This makes the error message more useful when trying to debug problems.
Example of the new output:

    2015-06-08 16:07:04 [stage1-binutils] ERROR: could not find tree for ref
    ('b1d3b01332ae49a60ff5d6bf53d3a5b1805769c8',
    '/home/sam/ybd-builds/cache/gits/git___git_baserock_org_delta_binutils_redhat')