### PR TITLE
Don't mutate os.environ for each build

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,10 +48,10 @@ def log(component, message='', data=''):
     print(log_entry),
 
 
-def log_env(log, message=''):
+def log_env(log, env, message=''):
     with open(log, "a") as logfile:
-        for key in sorted(os.environ.keys()):
-            msg = os.environ[key] if 'PASSWORD' not in key else '(hidden)'
+        for key in sorted(env):
+            msg = env[key] if 'PASSWORD' not in key else '(hidden)'
             logfile.write('%s=%s\n' % (key, msg))
         logfile.write(message + '\n')
         logfile.flush()

--- a/definitions.py
+++ b/definitions.py
@@ -45,10 +45,11 @@ class Definitions():
             for filename in filenames:
                 if filename.endswith(('.def', '.morph')):
                     contents = self._load(os.path.join(dirname, filename))
-                    if things_have_changed and definitions_schema:
-                        app.log(filename, 'Validating schema')
-                        js.validate(contents, definitions_schema)
-                    self._tidy(contents)
+                    if contents is not None:
+                        if things_have_changed and definitions_schema:
+                            app.log(filename, 'Validating schema')
+                            js.validate(contents, definitions_schema)
+                        self._tidy(contents)
 
         if self._check_trees():
             for name in self.__definitions:


### PR DESCRIPTION
It's less messy to use a separate dict for the clean environment. This
also fixes YBD under Python 3, as you can't do 'dict.items() +
dict.items()' in Python 3.