### PR TITLE
Support for subsystems in clusters

### DIFF
--- a/ybd.py
+++ b/ybd.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (C) 2014-2015  Codethink Limited
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
The first commit reworks the deploy() function to be less recursive and easier to reason about, as well as putting the recursive call in the correct place to deploy subsystems properly.

The second commit changes the variable names in assemble(), as well as looking in the correct place for the "subsystems" key and not attempting to build clusters.

The third commit adds a shebang to ybd.py so that it can be run directly (i.e. `../../ybd.py clusters/release.morph`), and is pretty unrelated to the others.