### PR TITLE
Support for running extensions which depend on code in definitions

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,6 +79,7 @@ def setup(target, arch):
 
         settings['ybd-version'] = get_version(os.path.dirname(__file__))
         settings['defdir'] = os.getcwd()
+        settings['extsdir'] = os.path.join(settings['defdir'], 'extensions')
         settings['def-ver'] = get_version('.')
         settings['target'] = target
         settings['arch'] = arch

--- a/sandbox.py
+++ b/sandbox.py
@@ -214,6 +214,12 @@ def run_extension(this, deployment, step, method):
     else:
         envlist = ['UPGRADE=no']
 
+    if 'PYTHONPATH' in os.environ:
+        envlist.append('PYTHONPATH=%s:%s' % (os.environ['PYTHONPATH'],
+                                             app.settings['extsdir']))
+    else:
+        envlist.append('PYTHONPATH=%s' % app.settings['extsdir'])
+
     for key, value in deployment.iteritems():
         if key.isupper():
             envlist.append("%s=%s" % (key, value))

--- a/utils.py
+++ b/utils.py
@@ -135,6 +135,6 @@ def _find_extensions(paths):
 def find_extensions():
     '''Scan definitions for extensions.'''
 
-    paths = [os.path.join(app.settings['defdir'], 'extensions')]
+    paths = [app.settings['extsdir']]
 
     return _find_extensions(paths)


### PR DESCRIPTION
Currently the deployment extensions still depend on morphlib and cliapp, but I plan to remove those dependencies by making them instead depend only on code in `extensions/` in the defintions repository. This means that that directory will need to be in PYTHONPATH when the extensions are run.

I've tested using this to deploy a build-system-x86_64 tarball using my WIP branch of definitions that has no external dependencies.