### PR TITLE
Make Definitions class reentrant

### DIFF
--- a/definitions.py
+++ b/definitions.py
@@ -22,7 +22,7 @@ from subprocess import check_output, PIPE
 import hashlib
 
 
-class Definitions():
+class Definitions(object):
     __definitions = {}
     __trees = {}
 

--- a/ybd.py
+++ b/ybd.py
@@ -50,11 +50,11 @@ with app.setup(target, arch):
         with app.timer('DEFINITIONS', 'Parsing %s' % app.settings['def-ver']):
             defs = Definitions()
         with app.timer('CACHE-KEYS', 'Calculating'):
-            cache.get_cache(app.settings['target'])
+            cache.get_cache(defs, app.settings['target'])
         defs.save_trees()
 
         sandbox.executor = sandboxlib.executor_for_platform()
         app.log(target, 'Using %s for sandboxing' % sandbox.executor)
 
-        assemble(app.settings['target'])
-        deploy(app.settings['target'])
+        assemble(defs, app.settings['target'])
+        deploy(defs, app.settings['target'])


### PR DESCRIPTION
These patches make the Definitions class re-entrant, by storing the state as instance variables rather than class variables, and passing a single instance when it is needed, rather than instantiating a new object each time. This solves the first part of #35.

These patches do **not** solve the second part of #35, that is replacing the dicts with objects.