### PR TITLE
Always inspect subsystems recursively

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -99,12 +99,15 @@ def assemble(defs, target):
         app.log(target, 'Skipping assembly for', component.get('arch'))
         return None
 
+    def assemble_system_recursively(system):
+        assemble(defs, system['path'])
+        for subsystem in system.get('subsystems', []):
+            assemble_system_recursively(subsystem)
+
     with app.timer(component, 'Starting assembly'):
         sandbox.setup(component)
         for system_spec in component.get('systems', []):
-            assemble(defs, system_spec['path'])
-            for subsystem in system_spec.get('subsystems', []):
-                assemble(defs, subsystem['path'])
+            assemble_system_recursively(system_spec)
 
         dependencies = component.get('build-depends', [])
         random.shuffle(dependencies)

--- a/cache.py
+++ b/cache.py
@@ -52,13 +52,15 @@ def cache_key(defs, this):
         if definition.get(factor):
             hash_factors[factor] = definition[factor]
 
+    def hash_system_recursively(system):
+        factor = system.get('path', 'BROKEN')
+        hash_factors[factor] = cache_key(defs, factor)
+        for subsystem in system.get('subsystems', []):
+            hash_system_recursively(subsystem)
+
     if definition.get('kind') == 'cluster':
         for system in definition.get('systems', []):
-            factor = system.get('path', 'BROKEN')
-            hash_factors[factor] = cache_key(defs, factor)
-            for subsystem in system.get('subsystems', []):
-                factor = subsystem.get('path', 'BROKEN')
-                hash_factors[factor] = cache_key(defs, factor)
+            hash_system_recursively(system)
 
     result = json.dumps(hash_factors, sort_keys=True).encode('utf-8')
 


### PR DESCRIPTION
Subsystems in clusters can be nested to arbitrary depth, so we need to look deeper than just the first 'subsystems' key.