### PR TITLE
Sort filenames and directories to prevent building components outside…

### DIFF
--- a/definitions.py
+++ b/definitions.py
@@ -38,6 +38,8 @@ class Definitions(object):
 
         things_have_changed = not self._check_trees()
         for dirname, dirnames, filenames in os.walk('.'):
+            filenames.sort()
+            dirnames.sort()
             if '.git' in dirnames:
                 dirnames.remove('.git')
             for filename in filenames:


### PR DESCRIPTION
… the system

This stops components from being built that are not included in a system's morphology, which would solve issue #21