### PR TITLE
Identify git repo even if it has no tags

### DIFF
--- a/app.py
+++ b/app.py
@@ -87,7 +87,7 @@ def setup(target, arch):
             settings[key] = value
         settings['pid'] = os.getpid()
         with open(os.devnull, "w") as fnull:
-            if call(['git', 'describe'], stdout=fnull, stderr=fnull):
+            if call(['git', 'describe', '--all'], stdout=fnull, stderr=fnull):
                 exit(target, 'ERROR: not a git repo', os.getcwd())
 
         settings['ybd-version'] = get_version(os.path.dirname(__file__))


### PR DESCRIPTION
If a git repo has no tags, a bare "git describe" will return an error.