### PR TITLE
Treat True and False as actual commands, rather than booleans.

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -159,6 +159,8 @@ def build(defs, this):
         if this.get(build_step):
             app.log(this, 'Running', build_step)
         for command in this.get(build_step, []):
+            if command is False: command = "false"
+            elif command is True: command = "true"
             sandbox.run_sandboxed(
                 this, command, env=env_vars,
                 allow_parallel=('build' in build_step))


### PR DESCRIPTION
It's quite easy to forget that "true" and "false" are special words in YAML,
and write "false" to halt the build process while debugging. This was treated
as a Boolean instead of a string, so causes an unhelpful error in ybd.

Since there is no use for booleans in morphologies, they should be treated as
strings.