### PR TITLE
Jjardon/xdg dirs

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,14 @@ def setup(target, arch):
         settings['target'] = target
         settings['arch'] = arch
 
-        for directory in ['base', 'caches', 'artifacts', 'gits', 'tmp',
+        settings['base'] = os.path.join(xdg_cache_home, settings['base'])
+        settings['artifacts'] = os.path.join(settings['base'], 'artifacts')
+        settings['gits'] = os.path.join(settings['base'], 'gits')
+        settings['tmp'] = os.path.join(settings['base'], 'tmp')
+        settings['ccache_dir'] = os.path.join(settings['base'], 'ccache_dir')
+        settings['deployment'] = os.path.join(settings['base'], 'deployment')
+
+        for directory in ['artifacts', 'gits', 'tmp',
                           'ccache_dir', 'deployment']:
             try:
                 os.makedirs(settings[directory])

--- a/ybd.def
+++ b/ybd.def
@@ -1,15 +1,9 @@
-artifacts: '/src/cache/ybd-artifacts'
 base-path: ['/usr/bin', '/bin', '/usr/sbin', '/sbin']
-base: '/src'
+base: 'ybd'
 cache-server: 'http://git.baserock.org:8080/1.0/sha1s?'
-caches: '/src/cache'
-ccache_dir: '/src/cache/ccache'
 defs-schema: './schema/definitions-schema.json'
-deployment: '/src/tmp/deployments'
-gits: '/src/cache/gits'
 json-schema: './schema/json-schema.json'
 no-ccache: False
 no-distcc: True
 server: 'http://192.168.56.102:8000/'
 tar-url: 'http://git.baserock.org/taballs'
-tmp: '/src/tmp'


### PR DESCRIPTION
I only left the "base" directory configurable through the config file, so ybd will put stuff in $XDG_CACHE_HOME/[base] (fallbacks to ~/.cache/[base])
I've move all the other internal directories ybd uses inside $XDG_CACHE_HOME/[base], so all the stuff is in the same place.
Not sure is there any value on tweak the location/name of this directories (I  have never change them in all these time using morph), so I've move them inside the code to make the configuration file smaller and cleaner; tell me if you dont agree with this and I will try to rework the patch