### PR TITLE
Don't print duplicated warning messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,9 @@ def setup(args):
     settings['arch'] = arch
 
     warnings.formatwarning = warning_handler
+    # Suppress multiple instances of the same warning.
+    warnings.simplefilter('once')
+
     settings_file = './ybd.conf'
     if not os.path.exists(settings_file):
         settings_file = os.path.join(os.path.dirname(__file__), 'ybd.conf')


### PR DESCRIPTION
Warnings reported with warnings.warn() will now only appear to the user
the first time they are reported. Previously the same message could be
repeated each time warnings.warn() was called.