### PR TITLE
Fix warnings filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,7 +96,7 @@ def setup(args):
 
     warnings.formatwarning = warning_handler
     # Suppress multiple instances of the same warning.
-    warnings.simplefilter('once')
+    warnings.simplefilter('once', append=True)
 
     settings_file = './ybd.conf'
     if not os.path.exists(settings_file):


### PR DESCRIPTION
Commit f8befae1139490e39a1f18d0a554fa9b7321dc13 added a warning filter
before all the other filters. This causes some uninteresting warnings
generated by Python due to bad code in installed libraries to start
appearing, in some cases. If add the warning filter *after* the existing
filters then these warnings remain hidden.