### PR TITLE
Remove build system autodetection

### DIFF
--- a/assembly.py
+++ b/assembly.py
@@ -189,11 +189,6 @@ def get_build_commands(defs, this):
     The definition containing build instructions can specify a predefined
     build-system and then override some or all of the command sequences it
     defines.
-
-    If the definition file doesn't exist and no build-system is specified,
-    this function will scan the contents the checked-out source repo and try
-    to autodetect what build system is used.
-
     '''
 
     if this.get('kind', None) == "system":
@@ -201,19 +196,8 @@ def get_build_commands(defs, this):
         this['install-commands'] = gather_integration_commands(defs, this)
         return
 
-    build_system = None
-    if 'build-system' in this:
-        build_system = buildsystem.lookup_build_system(this['build-system'])
-    else:
-        if os.path.exists(this['path']):
-            build_system = buildsystem.lookup_build_system(
-                this.get('build-system'),
-                default=buildsystem.ManualBuildSystem)
-        else:
-            files = os.listdir(this['build'])
-            build_system = buildsystem.detect_build_system(files)
-            app.log(this, 'Attempting to autodetect build system, got:',
-                    build_system.name)
+    build_system_name = this.get('build-system', 'manual')
+    build_system = buildsystem.lookup_build_system(build_system_name)
 
     for build_step in buildsystem.build_steps:
         if this.get(build_step, None) is None:

--- a/buildsystem.py
+++ b/buildsystem.py
@@ -254,6 +254,7 @@ class QMakeBuildSystem(BuildSystem):
         return False
 
 build_systems = [
+    ManualBuildSystem(),
     AutotoolsBuildSystem(),
     PythonDistutilsBuildSystem(),
     CPANBuildSystem(),
@@ -270,3 +271,19 @@ def detect_build_system(file_list):
         if build_system.used_by_project(file_list):
             return build_system
     return ManualBuildSystem()
+
+
+def lookup_build_system(name, default=None):
+    '''Return build system that corresponds to the name.
+
+    If the name does not match any build system, raise ``KeyError``.
+
+    '''
+
+    for bs in build_systems:
+        if bs.name == name:
+            return bs
+    if default:
+        return default()
+    else:
+        raise KeyError('Unknown build system: %s' % name)

--- a/buildsystem.py
+++ b/buildsystem.py
@@ -52,15 +52,11 @@ _STRIP_COMMAND = r'''find "$DESTDIR" -type f \
 
 class BuildSystem(object):
 
-    '''An abstraction of an upstream build system.
+    '''Predefined commands for common build systems.
 
-    Some build systems are well known: autotools, for example.
-    Others are purely manual: there's a set of commands to run that
-    are specific for that project, and (almost) no other project uses them.
-    The Linux kernel would be an example of that.
-
-    This class provides an abstraction for these, including a method
-    to autodetect well known build systems.
+    Some build systems are well known: autotools, for example. We provide
+    pre-defined build commands for these so that they don't need to be copied
+    and pasted many times in the build instructions.
 
     '''
 
@@ -94,9 +90,6 @@ class ManualBuildSystem(BuildSystem):
         self.commands['build-commands'] = []
         self.commands['install-commands'] = []
 
-    def used_by_project(self, file_list):
-        return False
-
 
 class AutotoolsBuildSystem(BuildSystem):
 
@@ -122,18 +115,6 @@ class AutotoolsBuildSystem(BuildSystem):
             'make DESTDIR="$DESTDIR" install',
         ]
 
-    def used_by_project(self, file_list):
-        indicators = [
-            'autogen',
-            'autogen.sh',
-            'configure',
-            'configure.ac',
-            'configure.in',
-            'configure.in.in',
-        ]
-
-        return any(x in file_list for x in indicators)
-
 
 class PythonDistutilsBuildSystem(BuildSystem):
 
@@ -153,13 +134,6 @@ class PythonDistutilsBuildSystem(BuildSystem):
         self.commands['install-commands'] = [
             'python setup.py install --prefix "$PREFIX" --root "$DESTDIR"',
         ]
-
-    def used_by_project(self, file_list):
-        indicators = [
-            'setup.py',
-        ]
-
-        return any(x in file_list for x in indicators)
 
 
 class CPANBuildSystem(BuildSystem):
@@ -188,13 +162,6 @@ class CPANBuildSystem(BuildSystem):
             'make DESTDIR="$DESTDIR" install',
         ]
 
-    def used_by_project(self, file_list):
-        indicators = [
-            'Makefile.PL',
-        ]
-
-        return any(x in file_list for x in indicators)
-
 
 class CMakeBuildSystem(BuildSystem):
 
@@ -215,13 +182,6 @@ class CMakeBuildSystem(BuildSystem):
         self.commands['install-commands'] = [
             'make DESTDIR="$DESTDIR" install',
         ]
-
-    def used_by_project(self, file_list):
-        indicators = [
-            'CMakeLists.txt',
-        ]
-
-        return any(x in file_list for x in indicators)
 
 
 class QMakeBuildSystem(BuildSystem):
@@ -244,14 +204,6 @@ class QMakeBuildSystem(BuildSystem):
             'make INSTALL_ROOT="$DESTDIR" install',
         ]
 
-    def used_by_project(self, file_list):
-        indicator = '.pro'
-
-        for x in file_list:
-            if x.endswith(indicator):
-                return True
-
-        return False
 
 build_systems = [
     ManualBuildSystem(),
@@ -263,17 +215,7 @@ build_systems = [
 ]
 
 
-def detect_build_system(file_list):
-
-    '''Automatically detect the build system, if possible.'''
-
-    for build_system in build_systems:
-        if build_system.used_by_project(file_list):
-            return build_system
-    return ManualBuildSystem()
-
-
-def lookup_build_system(name, default=None):
+def lookup_build_system(name):
     '''Return build system that corresponds to the name.
 
     If the name does not match any build system, raise ``KeyError``.
@@ -283,7 +225,4 @@ def lookup_build_system(name, default=None):
     for bs in build_systems:
         if bs.name == name:
             return bs
-    if default:
-        return default()
-    else:
-        raise KeyError('Unknown build system: %s' % name)
+    raise KeyError('Unknown build system: %s' % name)


### PR DESCRIPTION
This will mean YBD cannot build Baserock definitions version 5 and earlier, so you probably don't want to merge it yet! Feel free to close and reopen at a later date.