### PR TITLE
config/defaults.conf: Some autotools projects use bootstrap[.sh]

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -29,7 +29,9 @@ build-systems:
     configure-commands:
     - |
       export NOCONFIGURE=1
-      if [ -e autogen ]; then ./autogen
+      if [ -e bootstrap ]; then ./bootstrap
+      elif [ -e bootstrap.sh ]; then ./bootstrap.sh
+      elif [ -e autogen ]; then ./autogen
       elif [ -e autogen.sh ]; then ./autogen.sh
       elif [ ! -e ./configure ]; then autoreconf -ivf
       fi


### PR DESCRIPTION
... instead the more common autogen[.sh]