### PR TITLE
Use move semantics instead of renames across the board

### DIFF
--- a/kbas/__main__.py
+++ b/kbas/__main__.py
@@ -143,8 +143,8 @@ class KeyedBinaryArtifactServer(object):
             checksum = cache.md5(artifact)
             with open(artifact + '.md5', "a") as f:
                 f.write(checksum)
-            os.rename(tmpdir, os.path.join(app.config['artifact-dir'],
-                                           cache_id))
+            shutil.move(tmpdir, os.path.join(app.config['artifact-dir'],
+                                             cache_id))
             response.status = 201  # success!
             return
         except:

--- a/ybd/cache.py
+++ b/ybd/cache.py
@@ -116,11 +116,11 @@ def cache(defs, this):
         shutil.rmtree(this['build'])
         utils.set_mtime_recursively(this['sandbox'])
         utils.make_deterministic_tar_archive(cachefile, this['sandbox'])
-        os.rename('%s.tar' % cachefile, cachefile)
+        shutil.move('%s.tar' % cachefile, cachefile)
     else:
         utils.set_mtime_recursively(this['install'])
         utils.make_deterministic_gztar_archive(cachefile, this['install'])
-        os.rename('%s.tar.gz' % cachefile, cachefile)
+        shutil.move('%s.tar.gz' % cachefile, cachefile)
 
     app.config['counter'].increment()
     unpack(defs, this, cachefile)
@@ -142,7 +142,7 @@ def unpack(defs, this, tmpfile):
 
     try:
         path = os.path.join(app.config['artifacts'], cache_key(defs, this))
-        os.rename(os.path.dirname(tmpfile), path)
+        shutil.move(os.path.dirname(tmpfile), path)
         if not os.path.isdir(path):
             app.exit(this, 'ERROR: problem creating cache artifact', path)
 
@@ -202,7 +202,7 @@ def get_cache(defs, this):
                 app.log(this, 'Problem unpacking', artifact)
                 return False
             try:
-                os.rename(tmpdir, unpackdir)
+                shutil.move(tmpdir, unpackdir)
             except:
                 # corner case... if we are here ybd is multi-instance, this
                 # artifact was uploaded from somewhere, and more than one
@@ -293,7 +293,7 @@ def cull(artifact_dir):
                 path = os.path.join(path, artifact + '.unpacked')
             if os.path.exists(path):
                 tmpdir = tempfile.mkdtemp()
-                os.rename(path, os.path.join(tmpdir, 'to-delete'))
+                shutil.move(path, os.path.join(tmpdir, 'to-delete'))
                 app.remove_dir(tmpdir)
                 deleted += 1
         return False

--- a/ybd/repos.py
+++ b/ybd/repos.py
@@ -137,7 +137,7 @@ def mirror(name, repo):
 
     gitdir = os.path.join(app.config['gits'], get_repo_name(repo))
     try:
-        os.rename(tmpdir, gitdir)
+        shutil.move(tmpdir, gitdir)
         app.log(name, 'Git repo is mirrored at', gitdir)
     except:
         pass


### PR DESCRIPTION
This branch simply changes all the call to os.rename() for shutil.move(), which will use os.rename() internally in the case that the destination happens to be on the same file system.

Not all changes in the branch are required, however it's better when reading the code if all moves are made with one API, this way we reduce the risk of os.rename() creeping back in places where it can be incorrect.