### PR TITLE
definitions.py: Log YAML parse errors while loading definitions

### DIFF
--- a/ybd/definitions.py
+++ b/ybd/definitions.py
@@ -100,9 +100,13 @@ class Definitions(object):
             with open(path) as f:
                 text = f.read()
             contents = yaml.safe_load(text)
-        except:
-            app.log('DEFINITIONS', 'WARNING: problem loading', path)
+        except yaml.YAMLError, exc:
+            app.log('DEFINITIONS', 'WARNING: Error parsing %s' % path, exc)
             return None
+        except:
+            app.log('DEFINITIONS', 'WARNING: Unexpected error loading', path)
+            return None
+
         if type(contents) is not dict:
             app.log('DEFINITIONS', 'WARNING: %s contents is not dict:' % path,
                     str(contents)[0:50])


### PR DESCRIPTION
This patch does not cause the build to bail out, which it probably
should, but at least meaningful parse errors are printed to the
console instead of just: "WARNING: problem loading <file>"

Instead an actual parse error sample looks like:

WARNING: Error parsing <file> while scanning for the next token
found character '\t' that cannot start any token
  in "<string>", line 20, column 1:
    	  GNU_TRIPLE=${GNU_TRIPLE}eabi
    ^