### PR TITLE
Fix subsystem deployment

### DIFF
--- a/ybd/deployment.py
+++ b/ybd/deployment.py
@@ -65,7 +65,8 @@ def deploy_system(defs, system_spec, parent_location=''):
                 for l in ['location', 'upgrade-location']:
                     if deployment.get(l):
                         deployment[l] = os.path.join(parent_location,
-                                                     l.lstrip('/'))
+                                                     deployment.get(
+                                                         l).lstrip('/'))
             try:
                 sandbox.run_extension(system, deployment, 'check', method)
             except KeyError:


### PR DESCRIPTION
This fixes https://github.com/devcurmudgeon/ybd/issues/213

When a subsystem is deployed, ybd rewrites the 'location' parameter of the
subsystem in the cluster definition such that it is prefixed with the path of
the temporary deployment directory for the containing system, so that it is
deployed into the containing system's unpacked tree.

Instead, ybd it prefixed the strings 'location' and 'upgrade-location' with
this path, producing an incorrect path for the subsystem deployment. As a
result, subsystems which are referred back to, in this case the initramfs
subsystem, are not found, in this case producing the following error:

    Failure to deploy system to genivi-demo-platform-x86_64-generic.img
    ERROR: INITRAMFS_PATH specified, but file does not exist
    16-04-29 00:02:17 [0/14/129] [base-system-x86_64-generic] ERROR: write extension failed: /home/ed/ybd-dev/definitions/extensions/rawdisk.write
    16-04-29 00:02:17 [0/14/129] [base-system-x86_64-generic] ERROR: a surprise exception happened