### PR TITLE
Fixes bug that ignores ybd.conf on cwd

### DIFF
--- a/ybd/__main__.py
+++ b/ybd/__main__.py
@@ -42,6 +42,7 @@ def write_cache_key():
 
 
 print('')
+original_cwd=os.getcwd()
 if not os.path.exists('./VERSION'):
     if os.path.basename(os.getcwd()) != 'definitions':
         if os.path.isdir(os.path.join(os.getcwd(), 'definitions')):
@@ -50,7 +51,7 @@ if not os.path.exists('./VERSION'):
             if os.path.isdir(os.path.join(os.getcwd(), '..', 'definitions')):
                 os.chdir(os.path.join(os.getcwd(), '..', 'definitions'))
 
-setup(sys.argv)
+setup(sys.argv, original_cwd)
 cleanup(config['tmp'])
 
 with timer('TOTAL'):

--- a/ybd/app.py
+++ b/ybd/app.py
@@ -125,7 +125,7 @@ def warning_handler(message, category, filename, lineno, file=None, line=None):
     return 'WARNING: %s\n' % (message)
 
 
-def setup(args):
+def setup(args, original_cwd=""):
     os.environ['LANG'] = 'en_US.UTF-8'
     config['start-time'] = datetime.datetime.now()
     config['program'] = os.path.basename(args[0])
@@ -156,6 +156,7 @@ def setup(args):
     load_configs([
         os.path.join(os.getcwd(), 'ybd.environment'),
         os.path.join(os.getcwd(), 'ybd.conf'),
+        os.path.join(original_cwd, 'ybd.conf'),
         os.path.join(os.path.dirname(__file__), '..', 'ybd.conf'),
         os.path.join(os.path.dirname(__file__), 'config', 'ybd.conf')])
 


### PR DESCRIPTION
Since the cwd can be modified by YBD at the start of execution, if a
user supplied config is provided, it will be ignored due to a new cwd
